### PR TITLE
Remove hardcoded arraos in qsub scripts (resolves #2)

### DIFF
--- a/qsub/tool_specific/BaseQualityScoreRecalibration/run.sh
+++ b/qsub/tool_specific/BaseQualityScoreRecalibration/run.sh
@@ -4,22 +4,22 @@ set -o nounset
 
 module load CBC gatk/${GATKVERSION}
 
-mkdir /scratch/arrao/BQSR_${SAMPLE} && cd /scratch/arrao/BQSR_${SAMPLE} 
-trap "{ rm -rf /scratch/arrao/BQSR_${SAMPLE} /scratch/arrao/${SAMPLE}_javatmp ; }" EXIT
+mkdir /scratch/${USER}/BQSR_${SAMPLE} && cd /scratch/${USER}/BQSR_${SAMPLE} 
+trap "{ rm -rf /scratch/${USER}/BQSR_${SAMPLE} /scratch/${USER}/${SAMPLE}_javatmp ; }" EXIT
 
 extension=${SAMFILE##*.}
 
 out_dir=$(dirname ${SAMFILE})
 out_base=$(basename ${SAMFILE%.${extension}})_BQSRd
 
-gatk --java-options "-Djava.io.tmpdir=/scratch/arrao/${SAMPLE}_javatmp -Xmx${MEMORY}g" \
+gatk --java-options "-Djava.io.tmpdir=/scratch/${USER}/${SAMPLE}_javatmp -Xmx${MEMORY}g" \
     BaseRecalibrator\
     --reference ${GENOMEREF} \
     --input ${SAMFILE} \
     --known-sites ${DBSNP} \
     --output ${out_base}_recal_data.table
 
-gatk --java-options "-Djava.io.tmpdir=/scratch/arrao/${SAMPLE}_javatmp -Xmx${MEMORY}g" \
+gatk --java-options "-Djava.io.tmpdir=/scratch/${USER}/${SAMPLE}_javatmp -Xmx${MEMORY}g" \
     ApplyBQSR \
     --create-output-bam-index true \
     --reference ${GENOMEREF} \
@@ -27,4 +27,4 @@ gatk --java-options "-Djava.io.tmpdir=/scratch/arrao/${SAMPLE}_javatmp -Xmx${MEM
     --bqsr-recal-file ${out_base}_recal_data.table \
     --output ${out_base}.bam
 
-mv /scratch/arrao/BQSR_${SAMPLE}/${out_base}* ${out_dir}/
+mv /scratch/${USER}/BQSR_${SAMPLE}/${out_base}* ${out_dir}/

--- a/qsub/tool_specific/CollectInsertSizeMetrics/run.sh
+++ b/qsub/tool_specific/CollectInsertSizeMetrics/run.sh
@@ -1,23 +1,24 @@
 #!/bin/bash
 
-# For Rscript histogram plotting
-source /home/arrao/miniconda3/etc/profile.d/conda.sh
-conda activate r_monocle2
+# For Rscript histogram plotting. Honestly doesn't really matter what env is used
+# as long as it has R and ggplot2.
+source /krummellab/data1/ipi/software/miniconda3/etc/profile.d/conda.sh
+conda activate r_seurat_3_6
 
 set -e
 set -o nounset
 
 module load CBC gatk/${GATKVERSION}   
 
-mkdir /scratch/arrao/ISizeMetrics_${SAMPLE} && cd /scratch/arrao/ISizeMetrics_${SAMPLE} 
-trap "{ rm -rf /scratch/arrao/ISizeMetrics_${SAMPLE} /scratch/arrao/${SAMPLE}_javatmp ; }" EXIT
+mkdir /scratch/${USER}/ISizeMetrics_${SAMPLE} && cd /scratch/${USER}/ISizeMetrics_${SAMPLE} 
+trap "{ rm -rf /scratch/${USER}/ISizeMetrics_${SAMPLE} /scratch/${USER}/${SAMPLE}_javatmp ; }" EXIT
 
 
 out_dir=$(dirname ${SAMFILE})
-gatk --java-options "-Djava.io.tmpdir=/scratch/arrao/${SAMPLE}_javatmp -Xmx${MEMORY}g" \
+gatk --java-options "-Djava.io.tmpdir=/scratch/${USER}/${SAMPLE}_javatmp -Xmx${MEMORY}g" \
    CollectInsertSizeMetrics \
    -I ${SAMFILE} \
    -O insert_size_metrics.txt \
    -H insert_size_histogram.pdf
 
-mv /scratch/arrao/ISizeMetrics_${SAMPLE}/insert_size_metrics* ${out_dir}/
+mv /scratch/${USER}/ISizeMetrics_${SAMPLE}/insert_size_metrics* ${out_dir}/

--- a/qsub/tool_specific/DepthOfCoverage/run.sh
+++ b/qsub/tool_specific/DepthOfCoverage/run.sh
@@ -3,8 +3,8 @@ set -e
 set -o nounset
 module load CBC gatk/${GATKVERSION}
 
-mkdir /scratch/arrao/DepthOfCoverage_${SAMPLE} && cd /scratch/arrao/DepthOfCoverage_${SAMPLE} 
-trap "{ rm -rf /scratch/arrao/DepthOfCoverage_${SAMPLE} /scratch/arrao/${SAMPLE}_javatmp ; }" EXIT
+mkdir /scratch/${USER}/DepthOfCoverage_${SAMPLE} && cd /scratch/${USER}/DepthOfCoverage_${SAMPLE} 
+trap "{ rm -rf /scratch/${USER}/DepthOfCoverage_${SAMPLE} /scratch/${USER}/${SAMPLE}_javatmp ; }" EXIT
 
 out_dir=$(dirname ${SAMFILE})
 
@@ -15,7 +15,7 @@ else
     INTERVALSTRING="--intervals ${INTERVALFILE}"
 fi
 
-java -Djava.io.tmpdir=/scratch/arrao/${SAMPLE}_javatmp -Xmx${MEMORY}g -jar $GATK_HOME/GenomeAnalysisTK.jar \
+java -Djava.io.tmpdir=/scratch/${USER}/${SAMPLE}_javatmp -Xmx${MEMORY}g -jar $GATK_HOME/GenomeAnalysisTK.jar \
     -T DepthOfCoverage \
     -I ${SAMFILE} \
     ${INTERVALSTRING} \
@@ -29,4 +29,4 @@ java -Djava.io.tmpdir=/scratch/arrao/${SAMPLE}_javatmp -Xmx${MEMORY}g -jar $GATK
     --summaryCoverageThreshold 50 \
     --summaryCoverageThreshold 100 
 
-mv /scratch/arrao/DepthOfCoverage_${SAMPLE}/ ${out_dir}/DepthOfCoverage/
+mv /scratch/${USER}/DepthOfCoverage_${SAMPLE}/ ${out_dir}/DepthOfCoverage/

--- a/qsub/tool_specific/HaplotypeCaller/run.sh
+++ b/qsub/tool_specific/HaplotypeCaller/run.sh
@@ -4,8 +4,8 @@ set -o nounset
 module load CBC gatk/${GATKVERSION}
 
 
-mkdir /scratch/arrao/HaplotypeCaller_${SAMPLE} && cd /scratch/arrao/HaplotypeCaller_${SAMPLE} 
-trap "{ rm -rf /scratch/arrao/HaplotypeCaller_${SAMPLE} /scratch/arrao/${SAMPLE}_javatmp ; }" EXIT
+mkdir /scratch/${USER}/HaplotypeCaller_${SAMPLE} && cd /scratch/${USER}/HaplotypeCaller_${SAMPLE} 
+trap "{ rm -rf /scratch/${USER}/HaplotypeCaller_${SAMPLE} /scratch/${USER}/${SAMPLE}_javatmp ; }" EXIT
 
 
 
@@ -43,7 +43,7 @@ fi
     
 
 out_dir=$(dirname ${SAMFILE})
-gatk --java-options "-Djava.io.tmpdir=/scratch/arrao/${SAMPLE}_javatmp -Xmx${MEMORY}g" \
+gatk --java-options "-Djava.io.tmpdir=/scratch/${USER}/${SAMPLE}_javatmp -Xmx${MEMORY}g" \
    HaplotypeCaller \
    ${INTERVALSTRING} \
    ${GVCFSTRING} \
@@ -55,4 +55,4 @@ gatk --java-options "-Djava.io.tmpdir=/scratch/arrao/${SAMPLE}_javatmp -Xmx${MEM
    --dont-use-soft-clipped-bases ${DONTUSESOFTCLIPPEDBASES}
    
 
-mv /scratch/arrao/HaplotypeCaller_${SAMPLE}/${SAMPLE}_GL* ${out_dir}/
+mv /scratch/${USER}/HaplotypeCaller_${SAMPLE}/${SAMPLE}_GL* ${out_dir}/

--- a/qsub/tool_specific/IndelRealignment/run.sh
+++ b/qsub/tool_specific/IndelRealignment/run.sh
@@ -4,19 +4,19 @@ set -o nounset
 
 module load CBC gatk/${GATKVERSION}
 
-mkdir /scratch/arrao/IndelRealignment_${SAMPLE} && cd /scratch/arrao/IndelRealignment_${SAMPLE} 
-trap "{ rm -rf /scratch/arrao/IndelRealignment_${SAMPLE} /scratch/arrao/${SAMPLE}_javatmp ; }" EXIT
+mkdir /scratch/${USER}/IndelRealignment_${SAMPLE} && cd /scratch/${USER}/IndelRealignment_${SAMPLE} 
+trap "{ rm -rf /scratch/${USER}/IndelRealignment_${SAMPLE} /scratch/${USER}/${SAMPLE}_javatmp ; }" EXIT
 
 extension=${SAMFILE##*.}
 
 out_dir=$(dirname ${SAMFILE})
 out_base=$(basename ${SAMFILE%.${extension}})_IndelRealigned
 
-gatk --java-options "-Djava.io.tmpdir=/scratch/arrao/${SAMPLE}_javatmp -Xmx${MEMORY}g" \
+gatk --java-options "-Djava.io.tmpdir=/scratch/${USER}/${SAMPLE}_javatmp -Xmx${MEMORY}g" \
     LeftAlignIndels \
     --create-output-bam-index true \
     --reference ${GENOMEREF} \
     --input ${SAMFILE} \
     --OUTPUT ${out_base}.bam
 
-mv /scratch/arrao/IndelRealignment_${SAMPLE}/${out_base}* ${out_dir}/
+mv /scratch/${USER}/IndelRealignment_${SAMPLE}/${out_base}* ${out_dir}/

--- a/qsub/tool_specific/MarkDuplicates/run.sh
+++ b/qsub/tool_specific/MarkDuplicates/run.sh
@@ -4,19 +4,19 @@ set -o nounset
 
 module load CBC jdk/8
 
-mkdir /scratch/arrao/MarkDuplicates_${SAMPLE} && cd /scratch/arrao/MarkDuplicates_${SAMPLE} 
-trap "{ rm -rf /scratch/arrao/MarkDuplicates_${SAMPLE} ; }" EXIT
+mkdir /scratch/${USER}/MarkDuplicates_${SAMPLE} && cd /scratch/${USER}/MarkDuplicates_${SAMPLE} 
+trap "{ rm -rf /scratch/${USER}/MarkDuplicates_${SAMPLE} ; }" EXIT
 
 extension=${SAMFILE##*.}
 
 out_dir=$(dirname ${SAMFILE})
 out_base=$(basename ${SAMFILE%.${extension}})_DupMarked
 java -Xmx${MEMORY}g  \
-    -Djava.io.tmpdir=/scratch/arrao/${SAMPLE}_javatmp \
+    -Djava.io.tmpdir=/scratch/${USER}/${SAMPLE}_javatmp \
     -jar /krummellab/data1/ipi/software/picard/${PICARDVERSION}/picard.jar \
     MarkDuplicates \
     VALIDATION_STRINGENCY=SILENT \
-    TMP_DIR=/scratch/arrao/${SAMPLE}_picardtemp \
+    TMP_DIR=/scratch/${USER}/${SAMPLE}_picardtemp \
     REMOVE_DUPLICATES=${REMOVE_DUPLICATES} \
     REFERENCE_SEQUENCE=${GENOMEREF} \
     ASSUME_SORTED=true \
@@ -25,4 +25,4 @@ java -Xmx${MEMORY}g  \
     OUTPUT=${out_base}.bam \
     METRICS_FILE=${out_base}.duplication_metrics
 
-mv /scratch/arrao/MarkDuplicates_${SAMPLE}/${out_base}* ${out_dir}/
+mv /scratch/${USER}/MarkDuplicates_${SAMPLE}/${out_base}* ${out_dir}/

--- a/qsub/tool_specific/SplitNCigarReads/run.sh
+++ b/qsub/tool_specific/SplitNCigarReads/run.sh
@@ -4,17 +4,17 @@ set -o nounset
 module load CBC gatk/${GATKVERSION}
 
 
-mkdir /scratch/arrao/SplitNCigarReads_${SAMPLE} && cd /scratch/arrao/SplitNCigarReads_${SAMPLE} 
-trap "{ rm -rf /scratch/arrao/SplitNCigarReads_${SAMPLE} /scratch/arrao/${SAMPLE}_javatmp ; }" EXIT
+mkdir /scratch/${USER}/SplitNCigarReads_${SAMPLE} && cd /scratch/${USER}/SplitNCigarReads_${SAMPLE} 
+trap "{ rm -rf /scratch/${USER}/SplitNCigarReads_${SAMPLE} /scratch/${USER}/${SAMPLE}_javatmp ; }" EXIT
 
 extension=${SAMFILE##*.}
 
 out_dir=$(dirname ${SAMFILE})
 out_base=$(basename ${SAMFILE%.${extension}})_NCigSplit
-gatk --java-options "-Djava.io.tmpdir=/scratch/arrao/${SAMPLE}_javatmp -Xmx${MEMORY}g" \
+gatk --java-options "-Djava.io.tmpdir=/scratch/${USER}/${SAMPLE}_javatmp -Xmx${MEMORY}g" \
    SplitNCigarReads \
    -R ${GENOMEREF} \
    -I ${SAMFILE} \
    -O ${out_base}.bam
 
-mv /scratch/arrao/SplitNCigarReads_${SAMPLE}/${out_base}* ${out_dir}/
+mv /scratch/${USER}/SplitNCigarReads_${SAMPLE}/${out_base}* ${out_dir}/

--- a/qsub/tool_specific/VariantFiltration/run.sh
+++ b/qsub/tool_specific/VariantFiltration/run.sh
@@ -4,8 +4,8 @@ set -o nounset
 module load CBC gatk/${GATKVERSION}
 
 
-mkdir /scratch/arrao/VariantFiltration_${SAMPLE} && cd /scratch/arrao/VariantFiltration_${SAMPLE} 
-trap "{ rm -rf /scratch/arrao/VariantFiltration_${SAMPLE} /scratch/arrao/${SAMPLE}_javatmp ; }" EXIT
+mkdir /scratch/${USER}/VariantFiltration_${SAMPLE} && cd /scratch/${USER}/VariantFiltration_${SAMPLE} 
+trap "{ rm -rf /scratch/${USER}/VariantFiltration_${SAMPLE} /scratch/${USER}/${SAMPLE}_javatmp ; }" EXIT
 
 if [ ${INTERVALFILE-"EMPTY"} == "NONE" ]
 then
@@ -20,7 +20,7 @@ extension=${VCFFILE##*.}
 out_dir=$(dirname ${VCFFILE})
 out_base=$(basename ${VCFFILE%.${extension}})_filtered
 
-gatk --java-options "-Djava.io.tmpdir=/scratch/arrao/${SAMPLE}_javatmp -Xmx${MEMORY}g" \
+gatk --java-options "-Djava.io.tmpdir=/scratch/${USER}/${SAMPLE}_javatmp -Xmx${MEMORY}g" \
     VariantFiltration \
     ${INTERVALSTRING} \
     -R ${GENOMEREF} \
@@ -33,4 +33,4 @@ gatk --java-options "-Djava.io.tmpdir=/scratch/arrao/${SAMPLE}_javatmp -Xmx${MEM
 
 # TODO: Think about other filters to add
 
-mv /scratch/arrao/VariantFiltration_${SAMPLE}/${out_base}* ${out_dir}/
+mv /scratch/${USER}/VariantFiltration_${SAMPLE}/${out_base}* ${out_dir}/

--- a/qsub/tool_specific/bwa/run.sh
+++ b/qsub/tool_specific/bwa/run.sh
@@ -4,8 +4,8 @@ set -o nounset
 
 source /krummellab/data1/ipi/ipi_usr/SOURCE_THIS 
 
-mkdir /scratch/arrao/bwa_${SAMPLE} && cd /scratch/arrao/bwa_${SAMPLE} 
-trap "{ rm -rf /scratch/arrao/bwa_${SAMPLE} ; }" EXIT
+mkdir /scratch/${USER}/bwa_${SAMPLE} && cd /scratch/${USER}/bwa_${SAMPLE} 
+trap "{ rm -rf /scratch/${USER}/bwa_${SAMPLE} ; }" EXIT
 
 # This is old and will eb deleted soon.
 getRG(){

--- a/qsub/tool_specific/cellranger_count/run.sh
+++ b/qsub/tool_specific/cellranger_count/run.sh
@@ -4,8 +4,8 @@ set -o nounset
 
 module load CBC cellranger/3.0.2
 
-mkdir /scratch/arrao/cellranger_count_${SAMPLE} && cd /scratch/arrao/cellranger_count_${SAMPLE} 
-trap "{ rm -rf /scratch/arrao/cellranger_count_${SAMPLE} ; }" EXIT
+mkdir /scratch/${USER}/cellranger_count_${SAMPLE} && cd /scratch/${USER}/cellranger_count_${SAMPLE} 
+trap "{ rm -rf /scratch/${USER}/cellranger_count_${SAMPLE} ; }" EXIT
 
 featureref_argstring=" "
 if grep -q "Antibody Capture" ${LIBRARIES_CSV}
@@ -32,8 +32,8 @@ cellranger count --id=${SAMPLE} \
 
 if [ -f ${OUTDIR} ]
 then
-    mv /scratch/arrao/cellranger_count_${SAMPLE}/${SAMPLE}/outs ${OUTDIR}/${SAMPLE}_counts
+    mv /scratch/${USER}/cellranger_count_${SAMPLE}/${SAMPLE}/outs ${OUTDIR}/${SAMPLE}_counts
 else
     mkdir -p $(dirname ${OUTDIR})
-    mv /scratch/arrao/cellranger_count_${SAMPLE}/${SAMPLE}/outs ${OUTDIR}
+    mv /scratch/${USER}/cellranger_count_${SAMPLE}/${SAMPLE}/outs ${OUTDIR}
 fi

--- a/qsub/tool_specific/cellranger_mkfastq/run.sh
+++ b/qsub/tool_specific/cellranger_mkfastq/run.sh
@@ -2,13 +2,13 @@
 set -e
 set -o nounset
 
-source /krummellab/data1/arrao/scripts/bash/essentials.sh
+source /krummellab/data1/${USER}/aarao_scripts/bash/essentials.sh
 uuid=`randomstr 10`
 
 module load CBC cellranger/3.0.2
 
-mkdir -p /scratch/arrao/cellranger_mkfastq_${FLOWCELLID}_${uuid}/working  /scratch/arrao/cellranger_mkfastq_${FLOWCELLID}_${uuid}/working && cd /scratch/arrao/cellranger_mkfastq_${FLOWCELLID}_${uuid}/working 
-trap "{ rm -rf /scratch/arrao/cellranger_mkfastq_${FLOWCELLID}_${uuid} ; }" EXIT
+mkdir -p /scratch/${USER}/cellranger_mkfastq_${FLOWCELLID}_${uuid}/working  /scratch/${USER}/cellranger_mkfastq_${FLOWCELLID}_${uuid}/working && cd /scratch/${USER}/cellranger_mkfastq_${FLOWCELLID}_${uuid}/working 
+trap "{ rm -rf /scratch/${USER}/cellranger_mkfastq_${FLOWCELLID}_${uuid} ; }" EXIT
 
 fastq_dir=$(dirname $(pwd))/fastqs
 
@@ -41,7 +41,7 @@ do
   cd ${subfolder}
   echo "Validating entries within ${subfolder}"
   echo "Testing Gzip integrity"
-  ls *gz | xargs -n1 /krummellab/data1/arrao/scripts/bash/on_path/test_pigz_integrity
+  ls *gz | xargs -n1 /krummellab/data1/${USER}/aarao_scripts/bash/on_path/test_pigz_integrity
   echo "Generating md5sums"
   md5sum *.fastq.gz > md5checksum.txt
   echo ""

--- a/qsub/tool_specific/cellranger_vdj/run.sh
+++ b/qsub/tool_specific/cellranger_vdj/run.sh
@@ -2,13 +2,13 @@
 set -e
 set -o nounset
 
-source /krummellab/data1/arrao/scripts/bash/essentials.sh
+source /krummellab/data1/${USER}/aarao_scripts/bash/essentials.sh
 uuid=`randomstr 10`
 
 module load CBC cellranger/3.0.2
 
-mkdir /scratch/arrao/cellranger_vdj_${SAMPLE}_${uuid} && cd /scratch/arrao/cellranger_vdj_${SAMPLE}_${uuid} 
-trap "{ rm -rf /scratch/arrao/cellranger_vdj_${SAMPLE}_${uuid} ; }" EXIT
+mkdir /scratch/${USER}/cellranger_vdj_${SAMPLE}_${uuid} && cd /scratch/${USER}/cellranger_vdj_${SAMPLE}_${uuid} 
+trap "{ rm -rf /scratch/${USER}/cellranger_vdj_${SAMPLE}_${uuid} ; }" EXIT
 
 
 cellranger vdj --id=${SAMPLE} \
@@ -20,8 +20,8 @@ cellranger vdj --id=${SAMPLE} \
 
 if [ -f ${OUTDIR} ]
 then
-    mv /scratch/arrao/cellranger_vdj_${SAMPLE}_${uuid}/${SAMPLE}/outs ${OUTDIR}/${SAMPLE}_vdj_${uuid}
+    mv /scratch/${USER}/cellranger_vdj_${SAMPLE}_${uuid}/${SAMPLE}/outs ${OUTDIR}/${SAMPLE}_vdj_${uuid}
 else
     mkdir -p $(dirname ${OUTDIR})
-    mv /scratch/arrao/cellranger_vdj_${SAMPLE}_${uuid}/${SAMPLE}/outs ${OUTDIR}
+    mv /scratch/${USER}/cellranger_vdj_${SAMPLE}_${uuid}/${SAMPLE}/outs ${OUTDIR}
 fi

--- a/qsub/tool_specific/fastp/run.sh
+++ b/qsub/tool_specific/fastp/run.sh
@@ -4,8 +4,8 @@ set -o nounset
 
 source /krummellab/data1/ipi/ipi_usr/SOURCE_THIS
 
-mkdir /scratch/arrao/fastp_${SAMPLE} && cd /scratch/arrao/fastp_${SAMPLE} 
-trap "{ rm -rf /scratch/arrao/fastp_${SAMPLE} ; }" EXIT
+mkdir /scratch/${USER}/fastp_${SAMPLE} && cd /scratch/${USER}/fastp_${SAMPLE} 
+trap "{ rm -rf /scratch/${USER}/fastp_${SAMPLE} ; }" EXIT
 
 getExtension() {
       x=${1##*.}
@@ -46,4 +46,4 @@ fastp -i ${FQ1} \
       -h ${SAMPLE}_fastp.html
 
 mkdir -p ${OUTDIR}
-mv /scratch/arrao/fastp_${SAMPLE}/* ${OUTDIR}/
+mv /scratch/${USER}/fastp_${SAMPLE}/* ${OUTDIR}/

--- a/qsub/tool_specific/freemuxlet/merge_perchrom.sh
+++ b/qsub/tool_specific/freemuxlet/merge_perchrom.sh
@@ -41,7 +41,7 @@ do
     fi
 done
 
-~/miniconda3/envs/pysam/bin/python /krummellab/data1/arrao/scripts/python/merge_perchrom_dsc_pileups.py \
+/krummellab/data1/ipi/software/miniconda3/envs/pysam/bin/python /krummellab/data1/${USER}/arrao_scripts/python/merge_perchrom_dsc_pileups.py \
     ${OUTDIR}/${prefix}_ ${OUTDIR}/${prefix}_MERGED ${BAMFILE} 
 
 popscle freemuxlet --plp ${OUTDIR}/${prefix}_MERGED \

--- a/qsub/tool_specific/freemuxlet/run.sh
+++ b/qsub/tool_specific/freemuxlet/run.sh
@@ -5,8 +5,8 @@ source /krummellab/data1/ipi/software/bedtools/2.29.2/SOURCE_THIS
 set -e
 set -o nounset
 
-mkdir -p /scratch/arrao/freemuxlet_${SAMPLE} && cd /scratch/arrao/freemuxlet_${SAMPLE}
-trap "{ rm -rf /scratch/arrao/freemuxlet_${SAMPLE}}" EXIT
+mkdir -p /scratch/${USER}/freemuxlet_${SAMPLE} && cd /scratch/${USER}/freemuxlet_${SAMPLE}
+trap "{ rm -rf /scratch/${USER}/freemuxlet_${SAMPLE}}" EXIT
 
 prefix=$(basename ${BAMFILE%.*})
 extension=${BAMFILE##*.}

--- a/qsub/tool_specific/process_10x_with_Seurat/run.sh
+++ b/qsub/tool_specific/process_10x_with_Seurat/run.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
-source /home/arrao/miniconda3/etc/profile.d/conda.sh
-conda activate r_monocle2
+source /krummellab/data1/ipi/software/miniconda3/etc/profile.d/conda.sh
+conda activate r_seurat_3_6
 
 set -e
 set -o nounset
 
 # None of thiw works right now!
-#start=`grep -n "args = list" /krummellab/data1/arrao/scripts/R/process_10x_with_Seurat.R | awk -F ":" '{print $1}'`
-#end=`grep -n "argsClasses = " /krummellab/data1/arrao/scripts/R/process_10x_with_Seurat.R | awk -F ":" '{print $1}'`
-#expected_args=(`tail -n+$((${start} + 1)) /krummellab/data1/arrao/scripts/R/process_10x_with_Seurat.R | 
+#start=`grep -n "args = list" /krummellab/data1/${USER}/scripts/R/process_10x_with_Seurat.R | awk -F ":" '{print $1}'`
+#end=`grep -n "argsClasses = " /krummellab/data1/${USER}/scripts/R/process_10x_with_Seurat.R | awk -F ":" '{print $1}'`
+#expected_args=(`tail -n+$((${start} + 1)) /krummellab/data1/${USER}/scripts/R/process_10x_with_Seurat.R | 
 #               head -$((${end} - ${start} - 1 )) | 
 #               grep "=" | 
 #               sed s/"=.*"//g`)
@@ -20,4 +20,4 @@ set -o nounset
 #    argstring+="${s}=`printenv ${s}` "
 #done
 
-Rscript /krummellab/data1/arrao/scripts/R/process_10x_with_Seurat.R SAMPLE_YML=${SAMPLE_YML} OUT_FOLDER=${OUT_FOLDER}
+Rscript /krummellab/data1/${USER}/arrao_scripts/R/process_10x_with_Seurat.R SAMPLE_YML=${SAMPLE_YML} OUT_FOLDER=${OUT_FOLDER}

--- a/qsub/tool_specific/strelka_Germline/run.sh
+++ b/qsub/tool_specific/strelka_Germline/run.sh
@@ -2,11 +2,11 @@
 set -e
 set -o nounset
 
-source /home/arrao/miniconda3/etc/profile.d/conda.sh
+source /home/${USER}/miniconda3/etc/profile.d/conda.sh
 conda activate strelka
 
-mkdir /scratch/arrao/strekla_GL_${SAMPLE} && cd /scratch/arrao/strekla_GL_${SAMPLE} 
-trap "{ rm -rf /scratch/arrao/strekla_GL_${SAMPLE} /scratch/arrao/${SAMPLE}_javatmp ; }" EXIT
+mkdir /scratch/${USER}/strekla_GL_${SAMPLE} && cd /scratch/${USER}/strekla_GL_${SAMPLE} 
+trap "{ rm -rf /scratch/${USER}/strekla_GL_${SAMPLE} /scratch/${USER}/${SAMPLE}_javatmp ; }" EXIT
 
 extension=${SAMFILE##*.}
 
@@ -26,4 +26,4 @@ ${SAMPLE}/runWorkflow.py \
        --jobs ${PBS_NUM_PPN} \
        --memGb ${MEMORY}
 
-mv /scratch/arrao/strekla_GL_${SAMPLE}/${SAMPLE}/results/ ${out_dir}/strelka/
+mv /scratch/${USER}/strekla_GL_${SAMPLE}/${SAMPLE}/results/ ${out_dir}/strelka/

--- a/qsub/tool_specific/template_argparse.sh
+++ b/qsub/tool_specific/template_argparse.sh
@@ -20,14 +20,14 @@ EOF
 
 read -r -d '' GLOBAL_OPTIONAL_HELPTEXT << EOF || true
 ## GLOBAL OPTIONAL PARAMETERS ##
-LOGDIR=/path/to/logdir (/krummellab/data1/arrao/logs)
+LOGDIR=/path/to/logdir (/krummellab/data1/${USER}/logs)
 NODEREQS=nodes=1:ppn=64
 MEMREQS=vmem=500gb
 EOF
 
 if [ ${LOGDIR-"EMPTY"} == "EMPTY" ]
 then
-    LOGDIR=/krummellab/data1/arrao/logs
+    LOGDIR=/krummellab/data1/${USER}/logs
 else
     LOGDIR=${LOGDIR#/}
 fi


### PR DESCRIPTION
resolves #2

1. Updated `tool-specific` qsub scripts using the new argparse to use
`/scratch/${USER}` instead of `/scratch/arrao`.
2. Updated some scripts  using `arrao_scripts` to use the instance in
`/krummellab/data1/${USER}`
3. Updated some scripts using a conda environment to use the appropriate
environment in `/krummellab/data1/ipi/software/miniconda3` instead of
`/home/arrao/miniconda3`