### PR TITLE
Fix the picard num cores issue (resolves #8)

### DIFF
--- a/qsub/tool_specific/AddOrReplaceReadGroups/run.sh
+++ b/qsub/tool_specific/AddOrReplaceReadGroups/run.sh
@@ -9,7 +9,8 @@ trap "{ rm -rf /scratch/arrao/AddRepRGs_${SAMPLE} ; }" EXIT
 
 out_dir=$(dirname ${BAMFILE})
 out_base=$(basename ${BAMFILE%.bam})_RGFixed
-java -Xmx${MEMORY}g  \
+java -XX:ParallelGCThreads=${PBS_NUM_PPN} \
+    -Xmx${MEMORY}g  \
     -Djava.io.tmpdir=/scratch/arrao/${SAMPLE}_javatmp \
     -jar /data/shared/krummellab/ipi/software/picard-2.18.14/picard.jar \
     AddOrReplaceReadGroups \

--- a/qsub/tool_specific/MarkDuplicates/run.sh
+++ b/qsub/tool_specific/MarkDuplicates/run.sh
@@ -11,7 +11,8 @@ extension=${SAMFILE##*.}
 
 out_dir=$(dirname ${SAMFILE})
 out_base=$(basename ${SAMFILE%.${extension}})_DupMarked
-java -Xmx${MEMORY}g  \
+java -XX:ParallelGCThreads=${PBS_NUM_PPN} \
+    -Xmx${MEMORY}g  \
     -Djava.io.tmpdir=/scratch/${USER}/${SAMPLE}_javatmp \
     -jar /krummellab/data1/ipi/software/picard/${PICARDVERSION}/picard.jar \
     MarkDuplicates \

--- a/qsub/tool_specific/bam2fq/run.sh
+++ b/qsub/tool_specific/bam2fq/run.sh
@@ -19,7 +19,8 @@ else
   exit 1
 fi
 
-java -Xmx100G -jar /data/shared/krummellab/ipi/software/picard-2.18.14/picard.jar SamToFastq I=unmapped.bam \
+java -XX:ParallelGCThreads=${PBS_NUM_PPN} \
+    -Xmx100G -jar /data/shared/krummellab/ipi/software/picard-2.18.14/picard.jar SamToFastq I=unmapped.bam \
     F=unmapped_1.fq \
     F2=unmapped_2.fq \
     FU=unmapped_up.fq \


### PR DESCRIPTION
resolves #8
Added `-XX:ParallelGCThreads=${PBS_NUM_PPN}` to MarkDuplicates which will force picard to respect the number of cores provided to the job.