### PR TITLE
Make Cellranger version an optional argument (resolves #10)

### DIFF
--- a/qsub/tool_specific/cellranger_count/run.sh
+++ b/qsub/tool_specific/cellranger_count/run.sh
@@ -2,9 +2,10 @@
 set -e
 set -o nounset
 
-module load CBC cellranger/3.0.2
+source /krummellab/data1/ipi/software/cellranger/usr/SOURCE_THIS
 
-mkdir /scratch/${USER}/cellranger_count_${SAMPLE} && cd /scratch/${USER}/cellranger_count_${SAMPLE} 
+mkdir /scratch/${USER}/cellranger_count_${SAMPLE}
+cd /scratch/${USER}/cellranger_count_${SAMPLE} 
 trap "{ rm -rf /scratch/${USER}/cellranger_count_${SAMPLE} ; }" EXIT
 
 featureref_argstring=" "
@@ -13,8 +14,9 @@ then
     featureref_argstring="--feature-ref ${FEATUREREF} "
 fi
 
+
 echo "running command: "
-echo "cellranger count --id=${SAMPLE} \
+echo "cellranger-${CELLRANGERVERSION} count --id=${SAMPLE} \
                  ${featureref_argstring} \
                  --libraries ${LIBRARIES_CSV} \
                  --chemistry=${CHEMISTRY} \
@@ -22,7 +24,7 @@ echo "cellranger count --id=${SAMPLE} \
                  --localcores=${PBS_NUM_PPN} \
                  --localmem=${MEMORY}"
                  
-cellranger count --id=${SAMPLE} \
+cellranger-${CELLRANGERVERSION} count --id=${SAMPLE} \
                  ${featureref_argstring} \
                  --libraries ${LIBRARIES_CSV} \
                  --chemistry=${CHEMISTRY} \

--- a/qsub/tool_specific/cellranger_mkfastq/run.sh
+++ b/qsub/tool_specific/cellranger_mkfastq/run.sh
@@ -5,9 +5,10 @@ set -o nounset
 source /krummellab/data1/${USER}/aarao_scripts/bash/essentials.sh
 uuid=`randomstr 10`
 
-module load CBC cellranger/3.0.2
+source /krummellab/data1/ipi/software/cellranger/usr/SOURCE_THIS
 
-mkdir -p /scratch/${USER}/cellranger_mkfastq_${FLOWCELLID}_${uuid}/working  /scratch/${USER}/cellranger_mkfastq_${FLOWCELLID}_${uuid}/working && cd /scratch/${USER}/cellranger_mkfastq_${FLOWCELLID}_${uuid}/working 
+mkdir -p /scratch/${USER}/cellranger_mkfastq_${FLOWCELLID}_${uuid}/working  /scratch/${USER}/cellranger_mkfastq_${FLOWCELLID}_${uuid}/working
+cd /scratch/${USER}/cellranger_mkfastq_${FLOWCELLID}_${uuid}/working 
 trap "{ rm -rf /scratch/${USER}/cellranger_mkfastq_${FLOWCELLID}_${uuid} ; }" EXIT
 
 fastq_dir=$(dirname $(pwd))/fastqs
@@ -19,7 +20,7 @@ then
 fi
 
 echo "running command: "
-echo "cellranger mkfastq --csv=${SAMPLESHEET} \
+echo "cellranger-${CELLRANGERVERSION} mkfastq --csv=${SAMPLESHEET} \
                    --run=${BCLDIR} \
                    --barcode-mismatches=${BARCODEMISMATCHES} \
                    ${lanes_argstring} \
@@ -27,7 +28,7 @@ echo "cellranger mkfastq --csv=${SAMPLESHEET} \
                    --localcores=${PBS_NUM_PPN} \
                    --localmem=${MEMORY} "
 
-cellranger mkfastq --csv=${SAMPLESHEET} \
+cellranger-${CELLRANGERVERSION} mkfastq --csv=${SAMPLESHEET} \
                    --run=${BCLDIR} \
                    --barcode-mismatches=${BARCODEMISMATCHES} \
                    ${lanes_argstring} \

--- a/qsub/tool_specific/cellranger_mkfastq/spawn.sh
+++ b/qsub/tool_specific/cellranger_mkfastq/spawn.sh
@@ -13,6 +13,7 @@ EOF
 
 read -r -d '' LOCAL_OPTIONAL_HELPTEXT  << EOF || true
 ## OPTIONAL PARAMETERS ##
+CELLRANGERVERSION  : The version of cellranger to use (3.0.2)
 BARCODEMISMATCHES  : Number of mismatches to allow in the barcode. (default=1)
 LANES              : Comma separated list of lanes to use. NO SPACES. (default=ALL)
 SAMPLESHEET        : Path to an Illumina samplesheet (default=<BCLDIR>/SampleSheet.csv)
@@ -24,6 +25,18 @@ if [ ${BCLDIR-"ERR"} == "ERR" ] || [ ${OUTDIR-"ERR"} == "ERR" ] || [ ${FLOWCELLI
 then
     echo -e "\nERROR: Required arguments cannot be empty\n"
     print_help  
+fi
+
+if [[ ! "${RECEIVED_NAMED_ARGS[@]}" =~ "CELLRANGERVERSION" ]]
+then
+    CELLRANGERVERSION="3.0.2"
+else
+    allowed=("3.0.2" "3.1.0" "4.0.0")
+    if [[ ! "${allowed[@]}" =~ "${CELLRANGERVERSION}" ]]
+    then
+        echo -e "\nERROR: CELLRANGERVERSION must be one of \n\t${allowed[@]}\n"
+        exit 1
+    fi
 fi
 
 if [[ ! "${RECEIVED_NAMED_ARGS[@]}" =~ "SAMPLESHEET" ]]
@@ -57,6 +70,7 @@ echo "BCLDIR              : "${BCLDIR-""}
 echo "OUTDIR              : "${OUTDIR-""}
 echo "FLOWCELLID          : "${FLOWCELLID-""}
 
+echo "CELLRANGERVERSION   : "${CELLRANGERVERSION-""}
 echo "SAMPLESHEET         : "${SAMPLESHEET-""}
 echo "BARCODEMISMATCHES   : "${BARCODEMISMATCHES-""}
 echo "LANES               : "${LANES-""}
@@ -72,6 +86,7 @@ BCLDIR=$(readlink -e ${BCLDIR}),\
 SAMPLESHEET=$(readlink -e ${SAMPLESHEET}),\
 OUTDIR=${OUTDIR},\
 FLOWCELLID=${FLOWCELLID},\
+CELLRANGERVERSION=${CELLRANGERVERSION},\
 BARCODEMISMATCHES=${BARCODEMISMATCHES},\
 LANES=${LANES},\
 MEMORY=${MEMORY}"

--- a/qsub/tool_specific/cellranger_vdj/run.sh
+++ b/qsub/tool_specific/cellranger_vdj/run.sh
@@ -5,13 +5,21 @@ set -o nounset
 source /krummellab/data1/${USER}/aarao_scripts/bash/essentials.sh
 uuid=`randomstr 10`
 
-module load CBC cellranger/3.0.2
+source /krummellab/data1/ipi/software/cellranger/usr/SOURCE_THIS
 
-mkdir /scratch/${USER}/cellranger_vdj_${SAMPLE}_${uuid} && cd /scratch/${USER}/cellranger_vdj_${SAMPLE}_${uuid} 
+mkdir /scratch/${USER}/cellranger_vdj_${SAMPLE}_${uuid}
+cd /scratch/${USER}/cellranger_vdj_${SAMPLE}_${uuid} 
 trap "{ rm -rf /scratch/${USER}/cellranger_vdj_${SAMPLE}_${uuid} ; }" EXIT
 
-
-cellranger vdj --id=${SAMPLE} \
+echo "running command: "
+echo "cellranger-${CELLRANGERVERSION} vdj --id=${SAMPLE} \
+               --fastqs=${FASTQDIR} \
+               --reference=${REFERENCE} \
+               --chain=${CHAIN} \
+               --localcores=${PBS_NUM_PPN} \
+               --localmem=${MEMORY}"
+               
+cellranger-${CELLRANGERVERSION} vdj --id=${SAMPLE} \
                --fastqs=${FASTQDIR} \
                --reference=${REFERENCE} \
                --chain=${CHAIN} \

--- a/qsub/tool_specific/cellranger_vdj/spawn.sh
+++ b/qsub/tool_specific/cellranger_vdj/spawn.sh
@@ -6,23 +6,36 @@ source $(dirname ${0})/../template_argparse.sh
 
 read -r -d '' REQUIRED_HELPTEXT  << EOF || true
 ## REQUIRED PARAMETERS ##
-FASTQDIR       : Path to the fastq directory
-SAMPLE         : The name of the sample
-OUTDIR         : A folder within which we will place the output dir
+FASTQDIR           : Path to the fastq directory
+SAMPLE             : The name of the sample
+OUTDIR             : A folder within which we will place the output dir
 EOF
 
 read -r -d '' LOCAL_OPTIONAL_HELPTEXT  << EOF || true
 ## OPTIONAL PARAMETERS ##
-NODEREQS       : Default node requirements (default: nodes=1:ppn=32)[overrides global default]
-MEMREQS        : Default mem requirements (default: vmem=250gb)[overrides global default]
-REFERENCE      : Path to 10X Indexes (default: /krummellab/data1/ipi/data/refs/10x/GRCh38_VDJ)
-CHAIN          : Chain to process [TR/IG/auto/all] (default: auto)
+CELLRANGERVERSION  : The version of cellranger to use (3.0.2)
+NODEREQS           : Default node requirements (default: nodes=1:ppn=32)[overrides global default]
+MEMREQS            : Default mem requirements (default: vmem=250gb)[overrides global default]
+REFERENCE          : Path to 10X Indexes (default: /krummellab/data1/ipi/data/refs/10x/GRCh38_VDJ)
+CHAIN              : Chain to process [TR/IG/auto/all] (default: auto)
 EOF
 
 if [ ${FASTQDIR-"ERR"} == "ERR" ] || [ ${SAMPLE-"ERR"} == "ERR" ] || [ ${OUTDIR-"ERR"} == "ERR" ]
 then
     echo -e "\nERROR: Required arguments cannot be empty\n"
     print_help  
+fi
+
+if [[ ! "${RECEIVED_NAMED_ARGS[@]}" =~ "CELLRANGERVERSION" ]]
+then
+    CELLRANGERVERSION="3.0.2"
+else
+    allowed=("3.0.2" "3.1.0" "4.0.0")
+    if [[ ! "${allowed[@]}" =~ "${CELLRANGERVERSION}" ]]
+    then
+        echo -e "\nERROR: CELLRANGERVERSION must be one of \n\t${allowed[@]}\n"
+        exit 1
+    fi
 fi
 
 # Override default NODEREQS and MEMREQS only if the user hasn't specified
@@ -61,15 +74,16 @@ fi
 
 
 echo "Received the following options:"
-echo "FASTQDIR       : "${FASTQDIR-""}
-echo "OUTDIR         : "${OUTDIR-""}
-echo "SAMPLE         : "${SAMPLE-""}
-echo "REFERENCE      : "${REFERENCE-""}
-echo "CHAIN          : "${CHAIN-""}
+echo "FASTQDIR           : "${FASTQDIR-""}
+echo "OUTDIR             : "${OUTDIR-""}
+echo "CELLRANGERVERSION  : "${CELLRANGERVERSION-""}
+echo "SAMPLE             : "${SAMPLE-""}
+echo "REFERENCE          : "${REFERENCE-""}
+echo "CHAIN              : "${CHAIN-""}
 
-echo "LOGDIR         : "${LOGDIR}
-echo "NODEREQS       : "${NODEREQS}
-echo "MEMREQS        : "${MEMREQS}
+echo "LOGDIR             : "${LOGDIR}
+echo "NODEREQS           : "${NODEREQS}
+echo "MEMREQS            : "${MEMREQS}
 echo -e "\n"
 
 MEMORY=`echo "$(echo ${MEMREQS} | sed 's/[^0-9]*//g')*0.9 / 1" | bc`
@@ -78,6 +92,7 @@ export_vars="\
 FASTQDIR=$(readlink -e ${FASTQDIR}),\
 SAMPLE=${SAMPLE},\
 OUTDIR=${OUTDIR},\
+CELLRANGERVERSION=${CELLRANGERVERSION},\
 REFERENCE=$(readlink -e ${REFERENCE}),\
 CHAIN=${CHAIN},\
 MEMORY=${MEMORY}"


### PR DESCRIPTION
resolves #10

1. Installed multiple versions od cellranger to
/krummellab/data1/ipi/software/cellranger
2. Added CELLRANGERVERSION as an option to all cellranger scripts
3. Using 3.0.2 as default for backwards compatibility
4. (Minor) split mkdir && cd for scratch dir to allow job crashing when
scratch dir exists.