### PR TITLE
Db/freemux merge var lengths

### DIFF
--- a/python/merge_freemuxlet_dsc_pileups.py
+++ b/python/merge_freemuxlet_dsc_pileups.py
@@ -56,7 +56,7 @@ def main():
             longest = max(num_lines, key=num_lines.get)
             longest_idx = [i for i, x in enumerate(fmx_ids['sample']==longest) if x][0]
             if len(set(list(num_lines.values()))) != 1:
-                print(f'!!Found var.gz files of different lengths, but assuming this is the fault of dscpileup and using the longest one, {longest}')
+                print(f'!!Found var.gz files of different lengths, but assuming this is not reference VCF-related, and using the longest one, {longest}')
             print('Writing merged.var.gz to disk')
             shutil.copy(os.path.join(fmx_ids.loc[longest_idx, 'freemuxlet_dir'], f'{longest}.var.gz'),
                         os.path.join(outdir, 'merged.var.gz'))

--- a/python/merge_freemuxlet_dsc_pileups.py
+++ b/python/merge_freemuxlet_dsc_pileups.py
@@ -64,7 +64,7 @@ def main():
             print(f'Found {fails} failures. Full list below.')
             for x, y in num_lines.items():
                 print(f'{x}: {y}')
-            raise RuntimeError('Freemuxlet runs used may have different VCFs for processing. If you know this to be false, run again with --IGNORE_DIFF_LENGTHS_ERROR added.')
+            raise RuntimeError('Freemuxlet runs used may have different VCFs for processing, or it may be just a freemuxlet bug. Check if the shorter .var files are simply some rows from the bottom of the longer counterparts.  If so, run again with --IGNORE_DIFF_LENGTHS_ERROR added.')
     else:
         print('Writing merged.var.gz to disk')
         shutil.copy(os.path.join(s.freemuxlet_dir, f'{s.sample}.var.gz'),

--- a/python/merge_freemuxlet_dsc_pileups.py
+++ b/python/merge_freemuxlet_dsc_pileups.py
@@ -3,7 +3,6 @@ import gzip
 import os
 import pandas as pd
 import shutil
-import difflib
 
 def main():
     parser = argparse.ArgumentParser()

--- a/python/merge_freemuxlet_dsc_pileups.py
+++ b/python/merge_freemuxlet_dsc_pileups.py
@@ -10,7 +10,7 @@ def main():
                         '`freemuxlet_dir`, and optionally `barcode_suffix`. The suffix need not '
                         'contain field separator (e.g. _2) since we will automatically apply `--`.')
     parser.add_argument('--outdir', required=True, help='An output directory')
-    parser.add_argument('--IGNORE_DIFF_LENGTHS_ERROR', action='store_true')
+    parser.add_argument('--ignore_diff_lengths_error', action='store_true')
     params = parser.parse_args()
 
     fmx_ids = pd.read_table(params.freemuxlet_dir_tsv, sep="\t", index_col=None, header=0)
@@ -52,7 +52,7 @@ def main():
         num_lines[s.sample] = x
 
     if fails > 0:
-        if params.IGNORE_DIFF_LENGTHS_ERROR:
+        if params.ignore_diff_lengths_error:
             longest = max(num_lines, key=num_lines.get)
             longest_idx = [i for i, x in enumerate(fmx_ids['sample']==longest) if x][0]
             if len(set(list(num_lines.values()))) != 1:
@@ -64,7 +64,7 @@ def main():
             print(f'Found {fails} failures. Full list below.')
             for x, y in num_lines.items():
                 print(f'{x}: {y}')
-            raise RuntimeError('Freemuxlet runs may have used different VCFs for processing, or it may be just a freemuxlet bug. Check if the shorter .var files are simply missing some rows from the bottom of the longer counterparts.  If so, run again with --IGNORE_DIFF_LENGTHS_ERROR added.')
+            raise RuntimeError('Freemuxlet runs may have used different VCFs for processing, or it may be just a freemuxlet bug. Check if the shorter .var files are simply missing some rows from the bottom of the longer counterparts.  If so, remove the merge directory and run again with --ignore_diff_lengths_error added.')
     else:
         print('Writing merged.var.gz to disk')
         shutil.copy(os.path.join(s.freemuxlet_dir, f'{s.sample}.var.gz'),

--- a/python/merge_freemuxlet_dsc_pileups.py
+++ b/python/merge_freemuxlet_dsc_pileups.py
@@ -43,7 +43,6 @@ def main():
     _x = None
     num_lines = {}
     fails = 0
-    # Collect nrows
     for s in fmx_ids.itertuples():
         with gzip.open(os.path.join(s.freemuxlet_dir, f'{s.sample}.var.gz')) as iff:
             x = len(iff.readlines())

--- a/python/merge_freemuxlet_dsc_pileups.py
+++ b/python/merge_freemuxlet_dsc_pileups.py
@@ -64,7 +64,7 @@ def main():
             print(f'Found {fails} failures. Full list below.')
             for x, y in num_lines.items():
                 print(f'{x}: {y}')
-            raise RuntimeError('Freemuxlet runs used may have different VCFs for processing, or it may be just a freemuxlet bug. Check if the shorter .var files are simply some rows from the bottom of the longer counterparts.  If so, run again with --IGNORE_DIFF_LENGTHS_ERROR added.')
+            raise RuntimeError('Freemuxlet runs may have used different VCFs for processing, or it may be just a freemuxlet bug. Check if the shorter .var files are simply missing some rows from the bottom of the longer counterparts.  If so, run again with --IGNORE_DIFF_LENGTHS_ERROR added.')
     else:
         print('Writing merged.var.gz to disk')
         shutil.copy(os.path.join(s.freemuxlet_dir, f'{s.sample}.var.gz'),


### PR DESCRIPTION
It seems there's a bug in freemuxlet's outputting where the `*.var.gz` output can become truncated.  This then leads to a runtime error, 'Freemuxlet runs used may have different VCFs for processing.',  being raised when running the `merge_freemuxlet_dsc_pileups.py` script.

This PR adds a flag, `--IGNORE_DIFF_LENGTHS_ERROR`, updates the initial error message in order to notify of this flag, and adds an alternative code path to get around the bug. 

The updated error message directs users to 1) check that shorter .var files are simply missing some lines at the bottom which exist in the longer .var files, and 2) if so, add the --IGNORE_DIFF_LENGTHS_ERROR flag.  The alternative path that's followed afterwards is to simply utilize the longest '.var.gz' output (and note this in the log).  